### PR TITLE
feat: Reintroduce latitude and longitude controls

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -1,6 +1,7 @@
 ### Features
 - Introduced the ability to test the connection during Enricher setup
 - Spaces in enricher configuration api key field will trigger an error message
+- Reintroduce latitude and longitude controls in enricher configuration page
 
 ### Fix
 - Rename enricher configuration api key field

--- a/src/ExternalSearch.Providers.GoogleMaps/Constants.cs
+++ b/src/ExternalSearch.Providers.GoogleMaps/Constants.cs
@@ -182,6 +182,22 @@ namespace CluedIn.ExternalSearch.Providers.GoogleMaps
                     Name = KeyName.PersonAddressCityKey,
                     Help = "The vocabulary key that contains the city addresses of persons you want to enrich (e.g., person.home.address.city)."
                 },
+                new()
+                {
+                    DisplayName = "Latitude Vocabulary Key",
+                    Type = "vocabularyKeySelector",
+                    IsRequired = false,
+                    Name = KeyName.LatitudeKey,
+                    Help = "The vocabulary key that contains the latitude you want to enrich (e.g., organization.latitude)."
+                },
+                new()
+                {
+                    DisplayName = "Longitude Vocabulary Key",
+                    Type = "vocabularyKeySelector",
+                    IsRequired = false,
+                    Name = KeyName.LongitudeKey,
+                    Help = "The vocabulary key that contains the longitude you want to enrich (e.g., organization.longitude)."
+                },
             }
         };
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Reintroduce the latitude and longitude controls into enricher configuration page (previously they were removed due to not being used in api, but now they are)


## How has it been tested? <!-- Remove if not needed -->
Manually in local
