### PR TITLE
fix: Make enrich flag case insensitive

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -8,3 +8,4 @@
 - Rename enricher configuration api key field
 - Resolve unable to enrich if no name vocabulary provided
 - Update deprecated api endpoint parameters
+- Make enrich control flag check to case insensitive

--- a/src/ExternalSearch.Providers.GoogleMaps/GoogleMapsExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.GoogleMaps/GoogleMapsExternalSearchProvider.cs
@@ -83,7 +83,7 @@ namespace CluedIn.ExternalSearch.Providers.GoogleMaps
 
             if (!string.IsNullOrWhiteSpace(config?.ControlFlag))
             {
-                if (request.EntityMetaData.Properties.GetValue(config.ControlFlag) != "true")
+                if (request.EntityMetaData.Properties.GetValue(config.ControlFlag)?.ToLowerInvariant() != "true")
                 {
                     context.Log.LogTrace($"Skipped enrichment for record {request.EntityMetaData.OriginEntityCode} because VocabularyKey {config.ControlFlag} value was not true. Actual value: {request.EntityMetaData.Properties.GetValue(config.ControlFlag)}");
                     yield break;


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Make the enrich control flag check to be case insensitive, which will allow true/TRUE/truE/trUE/xxx to work as long as it contain t,r,u,e 

## How has it been tested? <!-- Remove if not needed -->
Manually in local
