### PR TITLE
fix: Add unique origin entity code

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -9,3 +9,4 @@
 - Resolve unable to enrich if no name vocabulary provided
 - Update deprecated api endpoint parameters
 - Make enrich control flag check to case insensitive
+- Fix Topology not showing data from enricher

--- a/src/ExternalSearch.Providers.GoogleMaps/GoogleMapsExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.GoogleMaps/GoogleMapsExternalSearchProvider.cs
@@ -418,8 +418,8 @@ namespace CluedIn.ExternalSearch.Providers.GoogleMaps
         {
             if (result is IExternalSearchQueryResult<LocationDetailsResponse> locationDetailsResult)
             {
-                var clue = new Clue(request.EntityMetaData.OriginEntityCode, context.Organization);
-                clue.Data.EntityData.Codes.Add(request.EntityMetaData.Codes.First());
+                var code = new EntityCode(request.EntityMetaData.EntityType, "googlemaps", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+                var clue = new Clue(code, context.Organization);
 
                 this.PopulateLocationMetadata(clue.Data.EntityData, locationDetailsResult, request);
 
@@ -429,8 +429,8 @@ namespace CluedIn.ExternalSearch.Providers.GoogleMaps
             }
             else if (result is IExternalSearchQueryResult<CompanyDetailsResponse> companyResult)
             {
-
-                var clue = new Clue(request.EntityMetaData.OriginEntityCode, context.Organization);
+                var code = new EntityCode(request.EntityMetaData.EntityType, "googlemaps", $"{query.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+                var clue = new Clue(code, context.Organization);
 
                 this.PopulateCompanyMetadata(clue.Data.EntityData, companyResult, request);
 
@@ -576,9 +576,12 @@ namespace CluedIn.ExternalSearch.Providers.GoogleMaps
 
         private void PopulateLocationMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<LocationDetailsResponse> resultItem, IExternalSearchRequest request)
         {
+            var code = new EntityCode(request.EntityMetaData.EntityType, "googlemaps", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+
             metadata.EntityType = request.EntityMetaData.EntityType;
             metadata.Name = request.EntityMetaData.Name;
-            metadata.OriginEntityCode = request.EntityMetaData.OriginEntityCode;
+            metadata.OriginEntityCode = code;
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             //metadata.Properties[GoogleMapsVocabulary.Location.ComponentsAddress] = JsonUtility.Serialize(resultItem.Data.Result.AddressComponents);
             foreach (var component in resultItem.Data.Result.AddressComponents)
@@ -616,9 +619,12 @@ namespace CluedIn.ExternalSearch.Providers.GoogleMaps
 
         private void PopulateCompanyMetadata(IEntityMetadata metadata, IExternalSearchQueryResult<CompanyDetailsResponse> resultItem, IExternalSearchRequest request)
         {
+            var code = new EntityCode(request.EntityMetaData.EntityType, "googlemaps", $"{request.Queries.FirstOrDefault()?.QueryKey}{request.EntityMetaData.OriginEntityCode}".ToDeterministicGuid());
+
             metadata.EntityType = request.EntityMetaData.EntityType;
             metadata.Name = request.EntityMetaData.Name;
-            metadata.OriginEntityCode = request.EntityMetaData.OriginEntityCode;
+            metadata.OriginEntityCode = code;
+            metadata.Codes.Add(request.EntityMetaData.OriginEntityCode);
 
             //metadata.Properties[GoogleMapsVocabulary.Organization.AddressComponents] = JsonUtility.Serialize(resultItem.Data.Result.AddressComponents);
             foreach (var component in resultItem.Data.Result.AddressComponents)


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47706](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47706)

Topology now showing GoogleMaps data, but the one from other enricher turn into no source (Logo having issue)
![image](https://github.com/user-attachments/assets/a89adf13-044b-45c7-9b4c-6790eb91763d)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
